### PR TITLE
Adds two batch temperature-query APIs to WorldHelper

### DIFF
--- a/docs/performance-batch-temperature-query-cs.md
+++ b/docs/performance-batch-temperature-query-cs.md
@@ -1,186 +1,315 @@
 # Cold-Sweat Batch Temperature Query API – Specification
 
-## 1. Problem Statement
-
-The existing `WorldHelper.getTemperatureAt(Level, BlockPos)` computes the world temperature for a **single** position. It performs:
-
-- 25‑chunk scan for `HearthBlockEntity` insulation,
-- full `(2·range)³` (≈2744 blocks) volume scan for block temperature modifiers,
-- 49 biome sample queries,
-- dummy player WORLD modifier chain assembly.
-
-When many containers (e.g., in a storage room or ice‑box array) request temperatures individually, the cost scales as **N × S**, where N is the number of containers and S is the per‑position scan size. In clustered scenarios this is effectively O(N²). To mitigate this, we provide **batch APIs** that share expensive computations across many query positions.
+> **Scope:** this document specifies the batch world-temperature API shipped in Cold‑Sweat, covering **two rounds of updates** (see §1).
+> **Implementation status:** both rounds are implemented; Update 1 is committed, Update 2 is present in the working tree.
 
 ---
 
-## 2. Proposed API Additions (in `WorldHelper`)
+## 1. Update History
 
-### 2.1 Full‑precision batch API
-Semantically equivalent to `getTemperatureAt`, but for multiple positions at once.
+### Update 1 — Batch API foundation (committed)
+
+| Item | Value |
+|---|---|
+| Commit | `811dab1d9` — *feat(API): new APIs for batch temperature query* (current `HEAD`) |
+| Base for comparison | `ebf6bc52b` — *Remove boatload compat* |
+| Diff of the round | `ebf6bc52..811dab1d9`: 4 files changed, **691 insertions, 7 deletions** |
+
+Files added/changed in this round:
+
+| File | Change (`git diff --numstat ebf6bc52 HEAD`) |
+|---|---|
+| `docs/performance-batch-temperature-query-cs.md` | +186 / −0 (this specification) |
+| `api/temperature/modifier/BatchBlockTempModifier.java` | +33 / −0 (new) |
+| `util/world/BlockTempScanBatch.java` | +299 / −0 (new, first version) |
+| `util/world/WorldHelper.java` | +173 / −7 (`getTemperaturesAt`, `getRoughTemperaturesAt`, `getInsulationAtBatch`, `replaceBlockTempsWithBatch`) |
+
+Content of the round:
+
+- Public batch entry points on `WorldHelper` (full‑precision and coarse‑precision).
+- A per‑call scan context, `BlockTempScanBatch`, replacing the per‑position volume scan with a single region scan plus per‑source distribution.
+- Chunk‑de‑duplicated Hearth insulation lookup.
+- A public `TempModifier` adapter used to splice the pre‑computed contribution function into the existing WORLD modifier chain.
+
+### Update 2 — Scan region & per‑block overhead fix (working tree)
+
+| Item | Value (`git diff --numstat`, working tree) |
+|---|---|
+| `util/world/BlockTempScanBatch.java` | +148 / −59 — the whole of Update 2 |
+| `docs/performance-batch-temperature-query-cs.md` | revision of this document to match both rounds |
+| Commit state | both files are uncommitted at the time of writing; Update 1's commit `811dab1d9` remains `HEAD` |
+
+Motivation — in‑game profiling of the first version showed the remaining cost concentrated in `BlockTempScanBatch.scanUnionRegion`:
+
+| Hot spot | Share | Cause |
+|---|---|---|
+| `Long2ObjectOpenHashMap.get` | 17.66% | per‑block cache probe, but a single AABB pass visits each block exactly once → the probe always missed |
+| `LevelChunkSection.getBlockState` | 12.87% | proportional to the number of scanned blocks |
+| `Long2ObjectOpenHashMap.put` | 10.58% | paired with the useless probe above |
+| `HashMap.computeIfAbsent` | 2.88% | per‑column chunk lookup |
+
+Diagnosis: the first version scanned the **bounding box of all positions** (expanded by `range`). With containers scattered over the loaded area, that box covers large stretches of terrain containing no usable source at all, so the scanned volume — and therefore the `getBlockState` cost — grew with the spread of the positions rather than with the volume that can actually contribute.
+
+Content of the round (see §4.3):
+
+- Phase A now scans the **union of the per‑position influence boxes** (positions clustered by box overlap) instead of the bounding box of all positions — volumes between distant clusters are never touched.
+- Phase A reads blockstates **directly**, with no blockstate cache; disjoint clusters never share a block, so no block is read twice and the per‑block map traffic disappears.
+- The blockstate cache is retained but now serves **Phase B occlusion rays only**.
+- Refactor summary: `scanUnionRegion()` (single AABB) + `getRegionBounds()` are gone, replaced by `scanSources()` (union‑find clustering + per‑cluster bounds) and `scanClusterBox(...)` (chunk‑wise direct reads); `find`/`union` helpers were added.
+
+Measured outcome of both rounds: the periodic main‑thread spike is gone and the load is smooth in the reported scenario (verified in‑game by the maintainer).
+
+### Downstream consumer (different repository)
+
+`Freeze-It-And-Heat-It` (FIAHI) consumes this API from `ForgeEventHandler.onLevelTick`: it throttles per dimension, collects every eligible container position once per check tick, performs **one** batch query, then ticks the food stacks. It currently uses the coarse‑precision batch (`getRoughTemperaturesAt(..., 0)`) so that most throttled ticks are plain segment‑cache hits.
+
+---
+
+## 2. Problem Statement
+
+The pre‑existing `WorldHelper.getTemperatureAt(Level, BlockPos)` computes the world temperature for a **single** position. Each call performs:
+
+- a 25‑chunk scan for `HearthBlockEntity` insulation,
+- a full `(2·range)³` volume scan (≈2744 blocks at `range = 7`) for block‑temperature contributions,
+- biome sampling and elevation/shade queries,
+- a dummy player WORLD modifier chain assembly.
+
+The `(2·range)³` scan enumerates **every** block in the box, because ordinary blocks that carry a `BlockTemp` (fire, lava, ice, snow, configured heat/cold sources, …) have no spatial index to look them up by: the only way to find them is to read the volume. Minecraft provides such enumeration only for **block entities** (`ChunkAccess.getBlockEntities()`), which is why Hearth insulation can be batched by iterating chunk block entities while block temperatures cannot.
+
+When many containers (storage rooms, food arrays) request temperatures individually, cost scales as **N × S** (N = positions, S = per‑position scan) — effectively O(N²) for clustered layouts. The batch API shares the expensive parts across positions.
+
+---
+
+## 3. Public API Additions (`WorldHelper`)
+
+### 3.1 Full‑precision batch API
 
 ```java
 /**
- * Computes the world temperature for a batch of BlockPositions in the same Level.
- * <p>
- * Reuses dummy player modifier chain, block temperature volume scan across the union of
- * queried areas, and chunk‑wise insulation lookups to reduce repeated work.
+ * Computes the world temperature for a batch of positions in the same Level.
+ * Reuses the dummy player modifier chain, replaces the per‑position volume scan with a single
+ * scan over the union of the influence boxes, and de‑duplicates Hearth insulation lookups per chunk.
  *
- * @param level     the Level (must be server‑side, called on main thread)
- * @param positions a collection of BlockPos (duplicates are deduplicated)
- * @return an Object2DoubleMap mapping each unique position to its world temperature
- *         (in Minecraft temperature units)
- * @throws IllegalStateException if called on logical client or off the server thread
+ * @param level     the Level (server side; call from the server main thread)
+ * @param positions a collection of BlockPos (duplicates are de‑duplicated internally)
+ * @return an Object2DoubleMap mapping each de‑duplicated position to its world temperature
+ * @throws IllegalStateException if called on the logical client
  */
-public static Object2DoubleMap<BlockPos> getTemperaturesAt(
-    Level level,
-    Collection<BlockPos> positions
-)
+public static Object2DoubleMap<BlockPos> getTemperaturesAt(Level level, Collection<BlockPos> positions)
 ```
 
-### 2.2 Coarse‑precision batch API
-Semantically equivalent to `getRoughTemperatureAt`, reusing the 8‑block segment cache.
+Behaviour:
+
+- Positions are normalised through `sublevelToWorld` and de‑duplicated into a `LinkedHashSet` (insertion order preserved, so results are deterministic across calls); an empty batch returns an empty map immediately.
+- The shared batch scan runs once (`new BlockTempScanBatch(level, dummy, normalized, ConfigSettings.BLOCK_RANGE.get()).scan()`), and `getInsulationAtBatch(level, normalized, 2)` is queried once.
+- For each position the dummy is moved to the block centre and the WORLD chain is **cloned** (`Temperature.getModifiers` returns an immutable list, so the clone is required); the original `BlockTempModifier` step is replaced in place by the batch function, then `FrigidnessTempModifier` / `WarmthTempModifier` are appended when the position has cooling/heating levels > 0, and finally `Temperature.apply(0, dummy, Trait.WORLD, modifiers, true)` yields the value.
+
+### 3.2 Coarse‑precision batch API
 
 ```java
 /**
- * Computes rough world temperatures for a batch of positions, aligning with
- * getRoughTemperatureAt semantics and using the same segment cache.
+ * Computes rough world temperatures for a batch of positions, reusing the 8‑block segment cache.
  *
  * @param level     the Level
- * @param positions a collection of BlockPos
- * @param flags     cache flags (1=Sensitive, 2=Force Update) as in getRoughTemperatureAt
- * @return an Object2DoubleMap mapping each unique position to its rough temperature
+ * @param positions a collection of BlockPos (duplicates collapse onto the same key)
+ * @param flags     the same cache flags as getRoughTemperatureAt (1 = Sensitive, 2 = Force Update)
+ * @return an Object2DoubleMap mapping each position to its rough temperature
  */
-public static Object2DoubleMap<BlockPos> getRoughTemperaturesAt(
-    Level level,
-    Collection<BlockPos> positions,
-    int flags
-)
+public static Object2DoubleMap<BlockPos> getRoughTemperaturesAt(Level level, Collection<BlockPos> positions, int flags)
 ```
 
-**Return type:** Both use `it.unimi.dsi.fastutil.objects.Object2DoubleMap<BlockPos>` (fastutil), aligned with project usage.
+Behaviour: loops the positions through the existing `getRoughTemperatureAt(level, pos, flags)` cache path, writing one entry per position. No deduplication and no client‑side guard (the underlying method has none either).
 
-**Threading:** Must be called on the server main thread. Javadoc shall explicitly state this.
-
----
-
-## 3. Internal Implementation – `BlockTempScanBatch`
-
-The core of the batch optimisation is a **temporary, per‑call scanning context** that replaces the per‑position full‑volume scan with a **union scan + per‑source distribution**.
-
-### 3.1 Design Principles
-
-- **Not a singleton / cache:** It is instantiated fresh inside each `getTemperaturesAt` call, used only for that batch, and discarded after `buildResult()`.
-- **No cross‑tick pollution:** No static fields; safe from memory leaks and concurrency issues (server main thread only).
-- **Does not modify existing `BlockTempModifier` behaviour:** The original `BlockTempModifier.calculate()` remains unchanged; the batch uses a parallel code path.
-
-### 3.2 Class Structure
+### 3.3 Insulation batch API
 
 ```java
-class BlockTempScanBatch {
-    private final Level level;
-    private final Collection<BlockPos> positions;   // deduplicated
-    private final int range;                        // = BLOCK_RANGE
-    private final Map<Long, ChunkAccess> chunkCache; // LRU, per‑batch
-    private final Long2ObjectOpenHashMap<BlockState> stateCache; // per‑batch
-    // Per‑target‑pos accumulators: BlockTemp → accumulated value
-    private final Map<BlockPos, Map<BlockTemp, Double>> totals;
-    // Group accumulators for group‑wise clamping
-    private final Map<BlockPos, Map<TagKey<BlockTempData>, Double>> groupTotals;
-    // Temporary: source blocks (non‑air with blockTemp) found in union scan
-    private final Long2ObjectOpenHashMap<Collection<BlockTemp>> srcBlocks;
+/**
+ * De‑duplicated‑per‑chunk Hearth insulation query.
+ *
+ * @return the (max cooling level, max heating level) for each target position
+ */
+public static Map<BlockPos, Pair<Integer, Integer>> getInsulationAtBatch(Level level, Collection<BlockPos> positions, int chunkRadius)
+```
 
-    void scan();   // runs the two‑phase algorithm
-    Object2DoubleMap<BlockPos> buildResult(); // clamps and returns final temps
+> Note: this returns a **pair of levels**, not a temperature offset — a single `double` cannot carry both the cooling and the heating level.
+
+### 3.4 Modifier adapter
+
+```java
+public final class BatchBlockTempModifier extends TempModifier
+{
+    public BatchBlockTempModifier(Function<Double, Double> temperatureGetter);
+
+    @Override
+    protected Function<Double, Double> calculate(LivingEntity entity, Temperature.Trait trait);
 }
 ```
 
-### 3.3 Two‑Phase Algorithm
-
-**Phase A – Union volume scan (read blockstates once):**
-- Iterate over the **union of chunks** covered by all target positions.
-- For each block, read `blockstate` (via `stateCache`; shared across nearby positions).
-- Skip air / blocks with no `BlockTemp` (or only `DEFAULT_BLOCK_TEMP`).
-- Store matching source blocks and their `BlockTemp` collection into `srcBlocks`.
-- **Cost:** O(volume of union), not O(N × volume).
-
-**Phase B – Per‑source distribution (only within influence radius):**
-- For each source block and each of its `BlockTemp`:
-    - Pre‑filter: skip if no target position is within `blockTemp.range()`.
-    - For each target position within range:
-        - Compute distance (same as `WorldHelper.getClosestPointOnEntity` semantics).
-        - Compute occlusion via `forBlocksInRay` (ray from target to source) – this uses the shared `stateCache` and is called only for actual (source, target) pairs that are within range.
-        - Apply `fade()` and logarithmic rules, accumulate into `totals[pos][blockTemp]` and `groupTotals[pos][group]`.
-- **Cost:** O(number of source–target pairs within influence radius), which is far less than N × full volume when containers are clustered.
-
-**Clamping (`buildResult`):**
-For each target position, take the accumulated `Map<BlockTemp, Double>` and apply the same clamping logic as the single‑pos `calculate()` (clamp each BlockTemp’s contribution according to its min/max temperature and effect, then sum and clamp final). Output to `Object2DoubleMap<BlockPos>`.
-
-### 3.4 Comparison with Single‑pos `BlockTempModifier.calculate()`
-
-| Aspect | Single‑pos | Batch (`BlockTempScanBatch`) |
-|--------|------------|------------------------------|
-| Volume traversal | Full `(2·range)³` per position | Union of all target positions once |
-| BlockState reads | One read per block per position | One read per block (shared via cache) |
-| Occlusion rays | For every (pos, source) combination | Same, but only for pairs within influence radius |
-| Accumulation | Single `Map<BlockTemp,Double>` per call | One `Map<BlockTemp,Double>` per target position |
-| Dummy player | Re‑assembled per call | Shared across the batch |
+A `public` adapter in `api.temperature.modifier` whose `calculate` returns the pre‑computed contribution function, so the existing chain semantics (ordering, clamping position in the chain) are preserved. It is **not** registered in `TempModifierRegistry`.
 
 ---
 
-## 4. Insulation Batching (`getInsulationAtBatch`)
+## 4. Internal Implementation — `BlockTempScanBatch`
 
-The existing `WorldHelper.getInsulationAt` scans 25 chunks per position. The batch version:
+A **temporary, per‑call scanning context**: instantiated inside a single `getTemperaturesAt` call, used for that batch only, then garbage‑collected. No static state, no global cache, no cleanup hook needed.
 
-- Collects the union of all chunks touched by the batch positions.
-- For each chunk, loads it once, iterates its `BlockEntities` once, and records `HearthBlockEntity` contributions (cooling/heating levels) into a map keyed by position.
-- Returns an `Object2DoubleMap<BlockPos>` with the insulation‑derived temperature offset for each target position.
+### 4.1 Design Principles
 
-This is a **private internal method** used by `getTemperaturesAt`.
+- **Not a singleton / cache:** created per call and discarded; nothing is retained across calls or ticks.
+- **No cross‑tick or cross‑dimension pollution:** fully local state (server main thread only).
+- **Existing behaviour untouched:** `BlockTempModifier.calculate()`, `getTemperatureAt` and `getRoughTemperatureAt` are unchanged; the batch is a parallel path.
+
+### 4.2 Class Structure (as implemented)
+
+```java
+public final class BlockTempScanBatch
+{
+    private static final double LOG_FACTOR = 0.52;
+
+    private final Level level;
+    private final LivingEntity entity;          // the dummy player (observer)
+    private final Set<BlockPos> positions;      // already de‑duplicated and sublevel‑mapped
+    private final int range;                    // = ConfigSettings.BLOCK_RANGE
+
+    final Map<Long, ChunkAccess> chunkCache;    // LRU, shared across the batch
+    final Long2ObjectOpenHashMap<BlockState> stateCache;   // Phase B occlusion rays only
+
+    private final Map<BlockPos, Map<BlockTemp, Double>> totals;                    // per‑pos accumulators
+    private final Map<BlockPos, Map<TagKey<BlockTempData>, Double>> groupTotals;   // per‑pos group totals
+    private final List<Source> sources;         // candidate source blocks found in Phase A
+
+    private record Source(BlockPos pos, BlockState state) {}
+
+    public void scan();                                  // Phase A + Phase B
+    public Function<Double, Double> getFunction(BlockPos pos);   // final clamp closure
+
+    private void scanSources();                          // Phase A
+    private void scanClusterBox(int minX, int minY, int minZ, int maxX, int maxY, int maxZ);
+    private int find(int[] parent, int i);               // union‑find
+    private void union(int[] parent, int a, int b);
+    private void dispatchToPositions();                  // Phase B
+    private void accumulate(BlockPos pos, BlockTemp blockTemp, double temperature, int blocksOccluding, double distance);
+    private double getGroupTotal(BlockPos pos, BlockTemp blockTemp);
+    private boolean areAnyBlockTempsInRange(BlockPos pos, Collection<BlockTemp> blockTemps);
+    private void updateGroupTotal(BlockPos pos, BlockTemp blockTemp, double delta);
+    private ChunkAccess getChunk(BlockPos pos);
+}
+```
+
+> There is no `buildResult()` method: accumulation is finalised inside `getFunction(pos)`, which returns the same clamping closure shape used by the single‑position `calculate()`.
+
+### 4.3 Phase A — Union‑of‑boxes scan (Update 2)
+
+Phase A collects the candidate source blocks: non‑air blocks whose state carries a `BlockTemp` other than `DEFAULT_BLOCK_TEMP`.
+
+1. **Clustering.** Positions are partitioned with a union‑find over pair overlap: two positions share a cluster iff their `±range` boxes intersect, i.e. their **Chebyshev distance ≤ 2·range**. Pair checks are restricted to positions whose block chunks are within `chunkRadius = (2·range + 15) / 16` of one another (farther positions can never overlap), using a per‑chunk bucket so the number of comparisons stays proportional to local density rather than N².
+2. **Per‑cluster bounding box.** Each cluster is scanned over its own bounding box (member min/max ± `range`). Because disjoint clusters have disjoint (non‑intersecting) boxes, **no block is ever visited twice in a batch**, so Phase A needs no blockstate cache at all — each block is read once directly through `LevelChunkSection.getBlockState(lx, ly, lz)`.
+3. **Chunk‑wise traversal.** A cluster box is walked chunk by chunk (intersecting the box with each chunk's 16×16 column, fetching each chunk once through the batch LRU `chunkCache`), then `y` ascending with one section lookup per `y`, then the local `x`/`z` ranges. This avoids a per‑column chunk lookup and a per‑column packed‑key computation.
+4. Air states are skipped, and states whose `BlockTempRegistry.getBlockTempsFor(state)` is empty or only `DEFAULT_BLOCK_TEMP` are skipped; the rest are recorded as `Source(pos, state)`.
+
+**Why this is equivalent to the previous (bounding‑box) version:** a block can influence a position only if it lies inside that position's `±range` Chebyshev box (Euclidean distance ≤ range implies every axis difference ≤ range). The union of the per‑position boxes is therefore exactly the set of blocks that can contribute. Blocks in the old bounding box but outside every box were collected, then discarded by the Phase B `distance > range` test — dropping them changes no result.
+
+**Cost:** O(volume of the union of the per‑position boxes) blockstate reads, with no per‑block map traffic; plus one pass of cluster bookkeeping. The scan volume no longer grows with the empty space between distant positions.
+
+### 4.4 Phase B — Per‑source distribution
+
+For every source block, and for every target position:
+
+1. **Pre‑filter** (`areAnyBlockTempsInRange`): skip the pair if the position's accumulated value for these block temps can no longer change (all block temps already present and saturated within `minEffect`/`maxEffect`).
+2. The dummy is moved to the position's block centre (the observer), preserving the `entity` argument semantics of `BlockTemp.getTemperature`.
+3. Distance is measured from the closest point on the dummy's bounding box to the source block centre (`WorldHelper.getClosestPointOnEntity` + `CSMath.getDistance`); pairs beyond `range` are skipped.
+4. Occlusion is counted with `WorldHelper.forBlocksInRay(from, to, level, chunk, stateCache, tracer, 3)`, counting blocks for which `isSpreadBlocked` holds (excluding the source block itself). The shared `stateCache` is filled lazily by the ray helper, which is why it is kept for this phase.
+5. For each `BlockTemp` of the source state: `isValid` → `getTemperature(level, entity, state, src, distance)` → accumulate, then **break** — matching `BlockTempModifier`, which takes only the first effective `BlockTemp` per source block.
+
+Accumulation mirrors `BlockTempModifier` exactly: optional `fade()` blending over `(0.5, range)`, logarithmic growth with `LOG_FACTOR = 0.52`, damping by `(blocksOccluding + 1)`, and group‑aware clamping against `minEffect + groupDelta` / `maxEffect − groupDelta`.
+
+### 4.5 Result assembly
+
+`getFunction(pos)` returns a closure that walks the position's accumulated `Map<BlockTemp, Double>` and applies the same rule as the single‑position path: for each `BlockTemp`, if the running temperature is within `[minTemperature, maxTemperature]`, add its effect and clamp. Positions with no contributions get an identity closure, so chain order and behaviour are unchanged.
+
+### 4.6 Comparison with single‑position `BlockTempModifier.calculate()`
+
+| Aspect | Single‑position | Batch (`BlockTempScanBatch`) |
+|---|---|---|
+| Scan region | full `(2·range)³` per position | union of the per‑position boxes (clustered), once per batch |
+| BlockState reads | every block, per position | every block of the union, once per batch |
+| BlockState cache in scan | per‑call, cleared each call (always misses within one box) | none needed (no block is visited twice) |
+| Occlusion rays | every (position, source) pair within the box | same, but only for pairs within `range` |
+| Accumulation | one `Map<BlockTemp, Double>` per call | one `Map<BlockTemp, Double>` per target position |
+| Dummy player | re‑assembled per call | shared, repositioned per position |
+| Empty‑zone cost | scans regions with no sources | scans only the boxes that can contain sources |
 
 ---
 
-## 5. Coarse‑precision Batch Caching
+## 5. Insulation Batching (`getInsulationAtBatch`)
 
-`getRoughTemperatureAt` already uses a segmented cache (`TEMPERATURE_CHECKS`) with 8‑block granularity. The batch version simply iterates over the positions, checks the cache for each segment, and returns cached values (or computes and stores) – no additional shared structures needed.
+The single‑position `getInsulationAt(level, pos, 2)` scans `(2·2+1)² = 25` chunks per position. The batch version:
 
----
+1. normalises and de‑duplicates the positions;
+2. builds the **union of touched chunk columns** (each position's chunk ± `chunkRadius`);
+3. loads each chunk once, iterates `chunk.getBlockEntitiesPos()` once, and for every `HearthBlockEntity` compares `hearth.getPathLookup().containsKey(pos)` against the batch positions, keeping the **max** cooling/heating level per position;
+4. fills `(0, 0)` for positions with no Hearth coverage.
 
-## 6. Cache & Threading Considerations
-
-- **Cache cleanup:** Existing `clearCachesOnUnload` (called on `ServerStoppedEvent`) remains responsible for cleaning any static caches. The `BlockTempScanBatch` is **ephemeral** and requires no static cleanup.
-- **Thread safety:** All batch APIs are intended for server main thread only. They do not introduce new concurrency.
-- **No new persistent caches** beyond the existing `TEMPERATURE_CHECKS`; all batch‑specific state is garbage‑collected after the call.
-
----
-
-## 7. Acceptance Criteria
-
-**Correctness:**
-- For any given set of positions, the batch APIs produce results that are **functionally identical** (within floating‑point tolerance) to calling the single‑pos equivalents in a loop.
-- Existing `getTemperatureAt` and `getRoughTemperatureAt` behaviour remains unchanged (regression tests required).
-
-**Performance:**
-- In clustered scenarios (e.g., many containers in a small area), the batch API shows a significant reduction in wall‑clock time compared to individual calls.
-- Profiling (e.g., Spark) should show the volume scan cost dropping from O(N × V) to O(V + N × pairs_in_range), which is near O(N) for dense clusters.
-
-**Regression:**
-- No impact on insulation lookup, biome sampling, or other temperature modifiers.
+This is a `public static` helper (usable on its own), not a private detail.
 
 ---
 
-## 8. Risks & Mitigations
+## 6. Coarse‑Precision Batch Caching
+
+`getRoughTemperatureAt` already caches per 8‑block segment (`TEMPERATURE_CHECKS`, keyed by dimension) with a validity window of `interval / tickSpeedMultiplier` (`interval` = 1000 ticks, or 200 with the Sensitive flag; `tickSpeedMultiplier = 1 + randomTickSpeed / 20`). `getRoughTemperaturesAt` simply walks the batch through this path, so repeated queries for nearby positions and repeated ticks reuse snapshots; expired snapshots recompute the chain for that one position and are stored back. Consumers that do not need per‑block precision (e.g. slow food‑temperature drift) should prefer this API.
+
+---
+
+## 7. Semantics: Threshold Equivalence
+
+The batch path is **threshold‑equivalent** to the single‑position path, not bit‑for‑bit identical:
+
+- the cold/hot direction and magnitude of the result agree in normal scenarios;
+- exact floating‑point equality is not guaranteed, because block contributions are accumulated in **dispatch order** (per source block) rather than per‑position scan order, and floating‑point addition is not associative.
+
+Two deliberate, documented differences in evaluation domain:
+
+1. **Distance cut‑off.** The batch accumulates a source only for positions whose Euclidean distance (measured from the observer's closest point to the source centre) is **≤ `range`**. The single‑position path has no explicit cut‑off: it accumulates every source found inside its `(2·range)³` scan box. For `fade()`‑enabled block temps the difference vanishes (the fade blend returns exactly `0` at `distance ≥ range`); for non‑fade block temps it is confined to the box corners, where the single‑position path would still apply the full effect.
+2. **Scan box size.** The single‑position scan box is `(2·range)³` per axis‑aligned window `[-range, range)`, while the batch scans the closed `±range` box (i.e. `2·range + 1` blocks per axis) of each cluster, so the batch may additionally consider blocks on the far face of that window.
+
+This contract is stated in the Javadoc of `getTemperaturesAt`, `BlockTempScanBatch` and `getRoughTemperaturesAt`, and is the acceptance basis for consumers such as FIAHI (which only depends on the sign and increments of the temperature).
+
+---
+
+## 8. Performance Characteristics
+
+- **Single position:** unchanged (`getTemperatureAt` keeps its original behaviour and cost).
+- **Batch, clustered positions:** scan cost drops from N × (2·range)³ to the volume of the union of the boxes, plus O(source–position pairs within range) for Phase B.
+- **Batch, scattered positions (Update 2):** previously the scan covered the full bounding box of all positions, so scattered containers were scanned including all the empty terrain between them; now only the per‑cluster boxes are scanned, and per‑block cache traffic in Phase A is gone entirely.
+- **Consumers using the coarse API:** steady‑state cost per tick is a segment‑cache lookup per position, with recomputation spread naturally over ticks as individual segments expire.
+
+---
+
+## 9. Cache & Threading Considerations
+
+- **Cache cleanup:** the existing `clearCachesOnUnload` (on `ServerStoppedEvent`) remains responsible for static caches (`DUMMY_PLAYERS`, `TEMPERATURE_CHECKS`, …). `BlockTempScanBatch` is ephemeral and needs no cleanup.
+- **Threading:** the batch APIs are contracted for the **server main thread**; `getTemperaturesAt` additionally throws `IllegalStateException` when called on the logical client. No new concurrency is introduced (existing methods perform no thread check either).
+- **No new persistent caches** beyond the existing `TEMPERATURE_CHECKS`; all batch state is collected after the call.
+
+---
+
+## 10. Risks & Mitigations
 
 | Risk | Mitigation |
-|------|------------|
-| **Algorithm correctness** – phase B must match single‑pos semantics exactly, including fade/occlusion/logarithmic/group clamping. | Provide a side‑by‑side test harness that compares batch results to sequential results for random position sets. |
-| **Main‑thread latency** – union scan could still be heavy for huge batches. | Add an optional batch size limit or deferral mechanism (future work); initial implementation can rely on the existing tick‑interval throttling (already applied by FIAHI). |
-| **Memory** – per‑batch maps can grow with batch size. | Acceptable for typical container counts (< few thousand); large worlds may need budget controls (post‑launch). |
+|---|---|
+| **Algorithmic correctness** — Phase B must reproduce single‑position semantics for fade/occlusion/logarithmic/group clamping. | The Phase B logic mirrors `BlockTempModifier` step by step; provide a side‑by‑side harness comparing batch and sequential results over random position sets on a threshold basis. |
+| **Clustering edge cases** — diagonal members, differing `y`, single‑position clusters, empty batches. | Union‑find uses the exact `Chebyshev ≤ 2·range` overlap test; a single‑position cluster degenerates to the single‑position box; empty input returns early. |
+| **Residual main‑thread latency** — a very large batch still runs in one tick. | Consumers should throttle per dimension (as FIAHI does) and/or use the coarse API; a work‑budget/deferral scheme remains future work. |
+| **Memory** — per‑batch maps grow with batch size. | Acceptable for typical container counts; budget controls are post‑launch work. |
 
 ---
 
-## 9. Delivery Plan
+## 11. Delivery Status
 
-1. **Implement** `BlockTempScanBatch` and the public batch APIs in `WorldHelper`.
-2. **Add** private batching helpers for insulation and dummy player reuse.
-3. **Test** thoroughly against sequential equivalents; include unit tests and integration tests.
-4. **Release** a new Cold‑Sweat version (with the new APIs) before FIAHI can upgrade its dependency.
+| Round | State |
+|---|---|
+| Update 1 (batch API, `BlockTempScanBatch` v1, insulation batching, spec) | committed as `811dab1d9` |
+| Update 2 (Phase A cluster scan + removal of Phase A blockstate cache) | implemented and verified in‑game; present in the working tree, pending commit |
+| Downstream consumption (FIAHI `ForgeEventHandler`, coarse batch per check tick) | implemented in the FIAHI repository |
+
+Verification performed: `compileJava` in both repositories succeeds; in‑game profiling after Update 2 shows the periodic spike removed.

--- a/docs/performance-batch-temperature-query-cs.md
+++ b/docs/performance-batch-temperature-query-cs.md
@@ -1,0 +1,186 @@
+# Cold-Sweat Batch Temperature Query API – Specification
+
+## 1. Problem Statement
+
+The existing `WorldHelper.getTemperatureAt(Level, BlockPos)` computes the world temperature for a **single** position. It performs:
+
+- 25‑chunk scan for `HearthBlockEntity` insulation,
+- full `(2·range)³` (≈2744 blocks) volume scan for block temperature modifiers,
+- 49 biome sample queries,
+- dummy player WORLD modifier chain assembly.
+
+When many containers (e.g., in a storage room or ice‑box array) request temperatures individually, the cost scales as **N × S**, where N is the number of containers and S is the per‑position scan size. In clustered scenarios this is effectively O(N²). To mitigate this, we provide **batch APIs** that share expensive computations across many query positions.
+
+---
+
+## 2. Proposed API Additions (in `WorldHelper`)
+
+### 2.1 Full‑precision batch API
+Semantically equivalent to `getTemperatureAt`, but for multiple positions at once.
+
+```java
+/**
+ * Computes the world temperature for a batch of BlockPositions in the same Level.
+ * <p>
+ * Reuses dummy player modifier chain, block temperature volume scan across the union of
+ * queried areas, and chunk‑wise insulation lookups to reduce repeated work.
+ *
+ * @param level     the Level (must be server‑side, called on main thread)
+ * @param positions a collection of BlockPos (duplicates are deduplicated)
+ * @return an Object2DoubleMap mapping each unique position to its world temperature
+ *         (in Minecraft temperature units)
+ * @throws IllegalStateException if called on logical client or off the server thread
+ */
+public static Object2DoubleMap<BlockPos> getTemperaturesAt(
+    Level level,
+    Collection<BlockPos> positions
+)
+```
+
+### 2.2 Coarse‑precision batch API
+Semantically equivalent to `getRoughTemperatureAt`, reusing the 8‑block segment cache.
+
+```java
+/**
+ * Computes rough world temperatures for a batch of positions, aligning with
+ * getRoughTemperatureAt semantics and using the same segment cache.
+ *
+ * @param level     the Level
+ * @param positions a collection of BlockPos
+ * @param flags     cache flags (1=Sensitive, 2=Force Update) as in getRoughTemperatureAt
+ * @return an Object2DoubleMap mapping each unique position to its rough temperature
+ */
+public static Object2DoubleMap<BlockPos> getRoughTemperaturesAt(
+    Level level,
+    Collection<BlockPos> positions,
+    int flags
+)
+```
+
+**Return type:** Both use `it.unimi.dsi.fastutil.objects.Object2DoubleMap<BlockPos>` (fastutil), aligned with project usage.
+
+**Threading:** Must be called on the server main thread. Javadoc shall explicitly state this.
+
+---
+
+## 3. Internal Implementation – `BlockTempScanBatch`
+
+The core of the batch optimisation is a **temporary, per‑call scanning context** that replaces the per‑position full‑volume scan with a **union scan + per‑source distribution**.
+
+### 3.1 Design Principles
+
+- **Not a singleton / cache:** It is instantiated fresh inside each `getTemperaturesAt` call, used only for that batch, and discarded after `buildResult()`.
+- **No cross‑tick pollution:** No static fields; safe from memory leaks and concurrency issues (server main thread only).
+- **Does not modify existing `BlockTempModifier` behaviour:** The original `BlockTempModifier.calculate()` remains unchanged; the batch uses a parallel code path.
+
+### 3.2 Class Structure
+
+```java
+class BlockTempScanBatch {
+    private final Level level;
+    private final Collection<BlockPos> positions;   // deduplicated
+    private final int range;                        // = BLOCK_RANGE
+    private final Map<Long, ChunkAccess> chunkCache; // LRU, per‑batch
+    private final Long2ObjectOpenHashMap<BlockState> stateCache; // per‑batch
+    // Per‑target‑pos accumulators: BlockTemp → accumulated value
+    private final Map<BlockPos, Map<BlockTemp, Double>> totals;
+    // Group accumulators for group‑wise clamping
+    private final Map<BlockPos, Map<TagKey<BlockTempData>, Double>> groupTotals;
+    // Temporary: source blocks (non‑air with blockTemp) found in union scan
+    private final Long2ObjectOpenHashMap<Collection<BlockTemp>> srcBlocks;
+
+    void scan();   // runs the two‑phase algorithm
+    Object2DoubleMap<BlockPos> buildResult(); // clamps and returns final temps
+}
+```
+
+### 3.3 Two‑Phase Algorithm
+
+**Phase A – Union volume scan (read blockstates once):**
+- Iterate over the **union of chunks** covered by all target positions.
+- For each block, read `blockstate` (via `stateCache`; shared across nearby positions).
+- Skip air / blocks with no `BlockTemp` (or only `DEFAULT_BLOCK_TEMP`).
+- Store matching source blocks and their `BlockTemp` collection into `srcBlocks`.
+- **Cost:** O(volume of union), not O(N × volume).
+
+**Phase B – Per‑source distribution (only within influence radius):**
+- For each source block and each of its `BlockTemp`:
+    - Pre‑filter: skip if no target position is within `blockTemp.range()`.
+    - For each target position within range:
+        - Compute distance (same as `WorldHelper.getClosestPointOnEntity` semantics).
+        - Compute occlusion via `forBlocksInRay` (ray from target to source) – this uses the shared `stateCache` and is called only for actual (source, target) pairs that are within range.
+        - Apply `fade()` and logarithmic rules, accumulate into `totals[pos][blockTemp]` and `groupTotals[pos][group]`.
+- **Cost:** O(number of source–target pairs within influence radius), which is far less than N × full volume when containers are clustered.
+
+**Clamping (`buildResult`):**
+For each target position, take the accumulated `Map<BlockTemp, Double>` and apply the same clamping logic as the single‑pos `calculate()` (clamp each BlockTemp’s contribution according to its min/max temperature and effect, then sum and clamp final). Output to `Object2DoubleMap<BlockPos>`.
+
+### 3.4 Comparison with Single‑pos `BlockTempModifier.calculate()`
+
+| Aspect | Single‑pos | Batch (`BlockTempScanBatch`) |
+|--------|------------|------------------------------|
+| Volume traversal | Full `(2·range)³` per position | Union of all target positions once |
+| BlockState reads | One read per block per position | One read per block (shared via cache) |
+| Occlusion rays | For every (pos, source) combination | Same, but only for pairs within influence radius |
+| Accumulation | Single `Map<BlockTemp,Double>` per call | One `Map<BlockTemp,Double>` per target position |
+| Dummy player | Re‑assembled per call | Shared across the batch |
+
+---
+
+## 4. Insulation Batching (`getInsulationAtBatch`)
+
+The existing `WorldHelper.getInsulationAt` scans 25 chunks per position. The batch version:
+
+- Collects the union of all chunks touched by the batch positions.
+- For each chunk, loads it once, iterates its `BlockEntities` once, and records `HearthBlockEntity` contributions (cooling/heating levels) into a map keyed by position.
+- Returns an `Object2DoubleMap<BlockPos>` with the insulation‑derived temperature offset for each target position.
+
+This is a **private internal method** used by `getTemperaturesAt`.
+
+---
+
+## 5. Coarse‑precision Batch Caching
+
+`getRoughTemperatureAt` already uses a segmented cache (`TEMPERATURE_CHECKS`) with 8‑block granularity. The batch version simply iterates over the positions, checks the cache for each segment, and returns cached values (or computes and stores) – no additional shared structures needed.
+
+---
+
+## 6. Cache & Threading Considerations
+
+- **Cache cleanup:** Existing `clearCachesOnUnload` (called on `ServerStoppedEvent`) remains responsible for cleaning any static caches. The `BlockTempScanBatch` is **ephemeral** and requires no static cleanup.
+- **Thread safety:** All batch APIs are intended for server main thread only. They do not introduce new concurrency.
+- **No new persistent caches** beyond the existing `TEMPERATURE_CHECKS`; all batch‑specific state is garbage‑collected after the call.
+
+---
+
+## 7. Acceptance Criteria
+
+**Correctness:**
+- For any given set of positions, the batch APIs produce results that are **functionally identical** (within floating‑point tolerance) to calling the single‑pos equivalents in a loop.
+- Existing `getTemperatureAt` and `getRoughTemperatureAt` behaviour remains unchanged (regression tests required).
+
+**Performance:**
+- In clustered scenarios (e.g., many containers in a small area), the batch API shows a significant reduction in wall‑clock time compared to individual calls.
+- Profiling (e.g., Spark) should show the volume scan cost dropping from O(N × V) to O(V + N × pairs_in_range), which is near O(N) for dense clusters.
+
+**Regression:**
+- No impact on insulation lookup, biome sampling, or other temperature modifiers.
+
+---
+
+## 8. Risks & Mitigations
+
+| Risk | Mitigation |
+|------|------------|
+| **Algorithm correctness** – phase B must match single‑pos semantics exactly, including fade/occlusion/logarithmic/group clamping. | Provide a side‑by‑side test harness that compares batch results to sequential results for random position sets. |
+| **Main‑thread latency** – union scan could still be heavy for huge batches. | Add an optional batch size limit or deferral mechanism (future work); initial implementation can rely on the existing tick‑interval throttling (already applied by FIAHI). |
+| **Memory** – per‑batch maps can grow with batch size. | Acceptable for typical container counts (< few thousand); large worlds may need budget controls (post‑launch). |
+
+---
+
+## 9. Delivery Plan
+
+1. **Implement** `BlockTempScanBatch` and the public batch APIs in `WorldHelper`.
+2. **Add** private batching helpers for insulation and dummy player reuse.
+3. **Test** thoroughly against sequential equivalents; include unit tests and integration tests.
+4. **Release** a new Cold‑Sweat version (with the new APIs) before FIAHI can upgrade its dependency.

--- a/src/main/java/com/momosoftworks/coldsweat/api/temperature/modifier/BatchBlockTempModifier.java
+++ b/src/main/java/com/momosoftworks/coldsweat/api/temperature/modifier/BatchBlockTempModifier.java
@@ -1,0 +1,33 @@
+package com.momosoftworks.coldsweat.api.temperature.modifier;
+
+import com.momosoftworks.coldsweat.api.util.Temperature;
+import net.minecraft.world.entity.LivingEntity;
+
+import java.util.function.Function;
+
+/**
+ * A {@link TempModifier} adapter used by the batch temperature computation: its {@link #calculate} directly
+ * returns a pre-computed block-temperature function instead of scanning the world.
+ * <br/>
+ * This is an internal wiring helper for {@code WorldHelper.getTemperaturesAt} and is not part of the registered
+ * modifier set, so it is never looked up through {@code TempModifierRegistry}.
+ *
+ * @author liudongyu
+ */
+public final class BatchBlockTempModifier extends TempModifier {
+	private final Function<Double, Double> temperatureGetter;
+
+	/**
+	 * Constructs a batch adapter backed by a pre-computed temperature function.
+	 *
+	 * @param temperatureGetter the pre-computed block-temperature function returned by {@code calculate}
+	 */
+	public BatchBlockTempModifier(Function<Double, Double> temperatureGetter) {
+		this.temperatureGetter = temperatureGetter;
+	}
+
+	@Override
+	protected Function<Double, Double> calculate(LivingEntity entity, Temperature.Trait trait) {
+		return this.temperatureGetter;
+	}
+}

--- a/src/main/java/com/momosoftworks/coldsweat/util/world/BlockTempScanBatch.java
+++ b/src/main/java/com/momosoftworks/coldsweat/util/world/BlockTempScanBatch.java
@@ -23,8 +23,8 @@ import java.util.*;
 import java.util.function.Function;
 
 /**
- * One-shot batch computation context carrying out the "scan the region union once, dispatch per-position"
- * block-temperature calculation for a batch of BlockPos positions within the same world.
+ * One-shot batch computation context carrying out the "scan the union of each position's influence box once,
+ * dispatch per-position" block-temperature calculation for a batch of BlockPos positions within the same world.
  * <br/>
  * Its lifetime is strictly bounded to a single {@link WorldHelper#getTemperaturesAt} call: the caller creates it
  * on the fly and discards it once the scan finishes. It is not held in any global cache, so it needs no cleanup
@@ -45,8 +45,10 @@ public final class BlockTempScanBatch
 	private final Set<BlockPos> positions;
 	private final int range;
 
-	// Chunk and blockstate caches shared across this batch.
+	// LRU chunk cache shared across this batch (chunks may host parts of several disjoint clusters).
 	final Map<Long, ChunkAccess> chunkCache = new LinkedHashMap<>(16, 0.75f, true);
+	// Blockstate cache used only by phase B occlusion rays (phase A reads states directly, since no block is
+	// ever visited twice across disjoint cluster boxes).
 	final Long2ObjectOpenHashMap<BlockState> stateCache = new Long2ObjectOpenHashMap<>(3000);
 
 	// Per-target-pos BlockTemp accumulated values / group-accumulated values.
@@ -72,12 +74,13 @@ public final class BlockTempScanBatch
 	}
 
 	/**
-	 * Runs the two-phase scan: phase A scans the region union and caches blockstates, phase B dispatches
-	 * accumulation to the target positions within each source block's affected radius.
+	 * Runs the two-phase scan: phase A scans the union of the per-position influence boxes once and collects the
+	 * candidate source blocks, phase B dispatches accumulation to the target positions within each source block's
+	 * affected radius.
 	 */
 	public void scan()
 	{
-		this.scanUnionRegion();
+		this.scanSources();
 		this.dispatchToPositions();
 	}
 
@@ -106,51 +109,156 @@ public final class BlockTempScanBatch
 		};
 	}
 
-	/** Phase A: scan the AABB union of all positions (expanded by range), reading and caching each blockstate. */
-	private void scanUnionRegion()
+	/**
+	 * Phase A: partition the target positions into clusters whose {@code ±range} boxes overlap, then scan each
+	 * cluster's own bounding box once. Disjoint clusters never share a block, so every block is read at most once
+	 * per batch and no block-state cache is needed here. This keeps the scanned volume proportional to the union of
+	 * the per-position boxes instead of the (potentially much larger) bounding box of all positions.
+	 */
+	private void scanSources()
 	{
-		long[] bounds = this.getRegionBounds();
-		int minX = (int) bounds[0];
-		int minY = (int) bounds[1];
-		int minZ = (int) bounds[2];
-		int maxX = (int) bounds[3];
-		int maxY = (int) bounds[4];
-		int maxZ = (int) bounds[5];
-		BlockPos.MutableBlockPos blockpos = new BlockPos.MutableBlockPos();
+		List<BlockPos> positionList = Lists.newArrayList(this.positions);
+		int count = positionList.size();
+		if (count == 0) return;
 
-		for (int x = minX; x <= maxX; x++)
+		// Union-find over positions: two positions belong to the same cluster iff their influence boxes overlap,
+		// i.e. their Chebyshev distance is at most 2 * range. Pair checks are limited to positions whose block
+		// chunks are within chunkRadius of each other, since farther positions can never overlap.
+		int[] parent = new int[count];
+		for (int i = 0; i < count; i++)
+		{   parent[i] = i;
+		}
+
+		Map<Long, List<Integer>> bucket = Maps.newHashMap();
+		for (int i = 0; i < count; i++)
 		{
-			int chunkX = x >> 4;
-			for (int z = minZ; z <= maxZ; z++)
+			BlockPos pos = positionList.get(i);
+			long chunkKey = ChunkPos.asLong(pos.getX() >> 4, pos.getZ() >> 4);
+			bucket.computeIfAbsent(chunkKey, key -> Lists.newArrayList()).add(i);
+		}
+
+		int chunkRadius = (this.range * 2 + 15) / 16;
+		for (Map.Entry<Long, List<Integer>> entry : bucket.entrySet())
+		{
+			long chunkKey = entry.getKey();
+			int chunkX = ChunkPos.getX(chunkKey);
+			int chunkZ = ChunkPos.getZ(chunkKey);
+			for (int dx = -chunkRadius; dx <= chunkRadius; dx++)
+			for (int dz = -chunkRadius; dz <= chunkRadius; dz++)
 			{
-				int chunkZ = z >> 4;
-				long chunkPos = ChunkPos.asLong(chunkX, chunkZ);
-				ChunkAccess chunk = this.chunkCache.computeIfAbsent(
-						chunkPos,
-						cp -> WorldHelper.getChunk(this.level, new ChunkPos(cp))
-				);
-				if (chunk == null) continue;
+				long neighborKey = ChunkPos.asLong(chunkX + dx, chunkZ + dz);
+				// Only process each unordered pair of buckets once (self-pairs included).
+				if (neighborKey < chunkKey) continue;
+				List<Integer> neighbor = bucket.get(neighborKey);
+				if (neighbor == null) continue;
 
-				for (int y = minY; y <= maxY; y++)
+				for (int i : entry.getValue())
+				for (int j : neighbor)
 				{
-					blockpos.set(x, y, z);
-					long blockPosLong = blockpos.asLong();
-					BlockState state = this.stateCache.get(blockPosLong);
-					if (state == null)
-					{
-						LevelChunkSection section = WorldHelper.getChunkSection(chunk, y);
-						state = section.getBlockState(x & 15, y & 15, z & 15);
-						this.stateCache.put(blockPosLong, state);
+					if (i == j || this.find(parent, i) == this.find(parent, j)) continue;
+					BlockPos a = positionList.get(i);
+					BlockPos b = positionList.get(j);
+					if (Math.abs(a.getX() - b.getX()) <= this.range * 2 &&
+							Math.abs(a.getY() - b.getY()) <= this.range * 2 &&
+							Math.abs(a.getZ() - b.getZ()) <= this.range * 2)
+					{   this.union(parent, i, j);
 					}
-					if (state.isAir()) continue;
-
-					Collection<BlockTemp> blockTemps = BlockTempRegistry.getBlockTempsFor(state);
-					if (blockTemps.isEmpty() || (blockTemps.size() == 1 && blockTemps.contains(BlockTempRegistry.DEFAULT_BLOCK_TEMP)))
-					{   continue;
-					}
-					this.sources.add(new Source(blockpos.immutable(), state));
 				}
 			}
+		}
+
+		// Accumulate cluster bounds (keyed by root index), then scan each cluster's bounding box once.
+		int[] minX = new int[count];
+		int[] minY = new int[count];
+		int[] minZ = new int[count];
+		int[] maxX = new int[count];
+		int[] maxY = new int[count];
+		int[] maxZ = new int[count];
+		Arrays.fill(minX, Integer.MAX_VALUE);
+		Arrays.fill(minY, Integer.MAX_VALUE);
+		Arrays.fill(minZ, Integer.MAX_VALUE);
+		Arrays.fill(maxX, Integer.MIN_VALUE);
+		Arrays.fill(maxY, Integer.MIN_VALUE);
+		Arrays.fill(maxZ, Integer.MIN_VALUE);
+		for (int i = 0; i < count; i++)
+		{
+			int root = this.find(parent, i);
+			BlockPos pos = positionList.get(i);
+			minX[root] = Math.min(minX[root], pos.getX());
+			minY[root] = Math.min(minY[root], pos.getY());
+			minZ[root] = Math.min(minZ[root], pos.getZ());
+			maxX[root] = Math.max(maxX[root], pos.getX());
+			maxY[root] = Math.max(maxY[root], pos.getY());
+			maxZ[root] = Math.max(maxZ[root], pos.getZ());
+		}
+		for (int i = 0; i < count; i++)
+		{
+			if (this.find(parent, i) != i) continue;
+			this.scanClusterBox(minX[i] - this.range, minY[i] - this.range, minZ[i] - this.range,
+								maxX[i] + this.range, maxY[i] + this.range, maxZ[i] + this.range);
+		}
+	}
+
+	/** Scans one cluster's bounding box chunk by chunk, reading every blockstate directly and collecting sources. */
+	private void scanClusterBox(int minX, int minY, int minZ, int maxX, int maxY, int maxZ)
+	{
+		BlockPos.MutableBlockPos blockpos = new BlockPos.MutableBlockPos();
+		for (int chunkX = minX >> 4; chunkX <= maxX >> 4; chunkX++)
+		for (int chunkZ = minZ >> 4; chunkZ <= maxZ >> 4; chunkZ++)
+		{
+			long chunkKey = ChunkPos.asLong(chunkX, chunkZ);
+			ChunkAccess chunk = this.chunkCache.get(chunkKey);
+			if (chunk == null)
+			{
+				chunk = WorldHelper.getChunk(this.level, new ChunkPos(chunkKey));
+				if (chunk == null) continue;
+				this.chunkCache.put(chunkKey, chunk);
+			}
+
+			int xStart = Math.max(minX, chunkX << 4);
+			int xEnd = Math.min(maxX, (chunkX << 4) | 15);
+			int zStart = Math.max(minZ, chunkZ << 4);
+			int zEnd = Math.min(maxZ, (chunkZ << 4) | 15);
+
+			for (int y = minY; y <= maxY; y++)
+			{
+				LevelChunkSection section = WorldHelper.getChunkSection(chunk, y);
+				int ly = y & 15;
+				for (int x = xStart; x <= xEnd; x++)
+				{
+					int lx = x & 15;
+					for (int z = zStart; z <= zEnd; z++)
+					{
+						BlockState state = section.getBlockState(lx, ly, z & 15);
+						if (state.isAir()) continue;
+
+						Collection<BlockTemp> blockTemps = BlockTempRegistry.getBlockTempsFor(state);
+						if (blockTemps.isEmpty() || (blockTemps.size() == 1 && blockTemps.contains(BlockTempRegistry.DEFAULT_BLOCK_TEMP)))
+						{   continue;
+						}
+						blockpos.set(x, y, z);
+						this.sources.add(new Source(blockpos.immutable(), state));
+					}
+				}
+			}
+		}
+	}
+
+	private int find(int[] parent, int i)
+	{
+		while (parent[i] != i)
+		{   parent[i] = parent[parent[i]];
+			i = parent[i];
+		}
+		return i;
+	}
+
+	private void union(int[] parent, int a, int b)
+	{
+		int rootA = this.find(parent, a);
+		int rootB = this.find(parent, b);
+		if (rootA != rootB)
+		{   parent[rootA] = rootB;
 		}
 	}
 
@@ -272,25 +380,6 @@ public final class BlockTempScanBatch
 
 	private ChunkAccess getChunk(BlockPos pos)
 	{   return WorldHelper.getChunk(this.level, pos);
-	}
-
-	/** Computes the AABB union covered by all positions, expanded outward by range. */
-	private long[] getRegionBounds()
-	{
-		int minX = Integer.MAX_VALUE;
-		int minY = Integer.MAX_VALUE;
-		int minZ = Integer.MAX_VALUE;
-		int maxX = Integer.MIN_VALUE;
-		int maxY = Integer.MIN_VALUE;
-		int maxZ = Integer.MIN_VALUE;
-		for (BlockPos pos : this.positions)
-		{
-			minX = Math.min(minX, pos.getX()); maxX = Math.max(maxX, pos.getX());
-			minY = Math.min(minY, pos.getY()); maxY = Math.max(maxY, pos.getY());
-			minZ = Math.min(minZ, pos.getZ()); maxZ = Math.max(maxZ, pos.getZ());
-		}
-		return new long[] { minX - this.range, minY - this.range, minZ - this.range,
-				maxX + this.range, maxY + this.range, maxZ + this.range };
 	}
 
 	// Candidate source blocks hit during phase A (state already read, so phase B does not read it again).

--- a/src/main/java/com/momosoftworks/coldsweat/util/world/BlockTempScanBatch.java
+++ b/src/main/java/com/momosoftworks/coldsweat/util/world/BlockTempScanBatch.java
@@ -1,0 +1,299 @@
+package com.momosoftworks.coldsweat.util.world;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.momosoftworks.coldsweat.api.registry.BlockTempRegistry;
+import com.momosoftworks.coldsweat.api.temperature.block_temp.BlockTemp;
+import com.momosoftworks.coldsweat.api.temperature.block_temp.ConfiguredBlockTemp;
+import com.momosoftworks.coldsweat.data.codec.configuration.BlockTempData;
+import com.momosoftworks.coldsweat.util.math.CSMath;
+import it.unimi.dsi.fastutil.longs.Long2ObjectOpenHashMap;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
+import net.minecraft.tags.TagKey;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.level.ChunkPos;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.chunk.ChunkAccess;
+import net.minecraft.world.level.chunk.LevelChunkSection;
+import net.minecraft.world.phys.Vec3;
+
+import java.util.*;
+import java.util.function.Function;
+
+/**
+ * One-shot batch computation context carrying out the "scan the region union once, dispatch per-position"
+ * block-temperature calculation for a batch of BlockPos positions within the same world.
+ * <br/>
+ * Its lifetime is strictly bounded to a single {@link WorldHelper#getTemperaturesAt} call: the caller creates it
+ * on the fly and discards it once the scan finishes. It is not held in any global cache, so it needs no cleanup
+ * on server stop and cannot leak across dimensions or ticks.
+ * <br/>
+ * Semantics: compared with the single-pos {@code BlockTempModifier.calculate()}, this class is threshold-equivalent
+ * in normal scenarios (same cold/hot direction and magnitude), but not bit-for-bit identical because the
+ * accumulation order is affected by the dispatch. Addons should validate against the "threshold-equivalent" contract.
+ *
+ * @author liudongyu
+ */
+public final class BlockTempScanBatch
+{
+	private static final double LOG_FACTOR = 0.52;
+
+	private final Level level;
+	private final LivingEntity entity;
+	private final Set<BlockPos> positions;
+	private final int range;
+
+	// Chunk and blockstate caches shared across this batch.
+	final Map<Long, ChunkAccess> chunkCache = new LinkedHashMap<>(16, 0.75f, true);
+	final Long2ObjectOpenHashMap<BlockState> stateCache = new Long2ObjectOpenHashMap<>(3000);
+
+	// Per-target-pos BlockTemp accumulated values / group-accumulated values.
+	private final Map<BlockPos, Map<BlockTemp, Double>> totals = Maps.newHashMap();
+	private final Map<BlockPos, Map<TagKey<BlockTempData>, Double>> groupTotals = Maps.newHashMap();
+
+	private final List<Source> sources = Lists.newArrayList();
+
+	/**
+	 * Constructs a batch computation context.
+	 *
+	 * @param level     the world the temperatures belong to (must be the same Level; call from the server main thread)
+	 * @param entity    the entity acting as the "observer" (the dummy player, preserving getTemperature semantics)
+	 * @param positions the target positions to probe (the caller should have de-duplicated and completed sublevel transforms)
+	 * @param range     the scan radius (== BLOCK_RANGE)
+	 */
+	public BlockTempScanBatch(Level level, LivingEntity entity, Set<BlockPos> positions, int range)
+	{
+		this.level = level;
+		this.entity = entity;
+		this.positions = positions;
+		this.range = range;
+	}
+
+	/**
+	 * Runs the two-phase scan: phase A scans the region union and caches blockstates, phase B dispatches
+	 * accumulation to the target positions within each source block's affected radius.
+	 */
+	public void scan()
+	{
+		this.scanUnionRegion();
+		this.dispatchToPositions();
+	}
+
+	/**
+	 * Returns the block-temperature contribution function for a given target position,
+	 * semantically aligned with the closure returned by {@code BlockTempModifier.calculate()}.
+	 *
+	 * @param pos the target position
+	 * @return the block-temperature function participating in the temperature chain (clamps the running temperature)
+	 */
+	public Function<Double, Double> getFunction(BlockPos pos)
+	{
+		Map<BlockTemp, Double> posTotals = this.totals.getOrDefault(pos, Map.of());
+		return temp ->
+		{
+			for (Map.Entry<BlockTemp, Double> entry : posTotals.entrySet())
+			{
+				BlockTemp blockTemp = entry.getKey();
+				double min = blockTemp.minTemperature();
+				double max = blockTemp.maxTemperature();
+				if (!CSMath.betweenInclusive(temp, min, max)) continue;
+				double effectValue = entry.getValue();
+				temp = CSMath.clamp(temp + effectValue, min, max);
+			}
+			return temp;
+		};
+	}
+
+	/** Phase A: scan the AABB union of all positions (expanded by range), reading and caching each blockstate. */
+	private void scanUnionRegion()
+	{
+		long[] bounds = this.getRegionBounds();
+		int minX = (int) bounds[0];
+		int minY = (int) bounds[1];
+		int minZ = (int) bounds[2];
+		int maxX = (int) bounds[3];
+		int maxY = (int) bounds[4];
+		int maxZ = (int) bounds[5];
+		BlockPos.MutableBlockPos blockpos = new BlockPos.MutableBlockPos();
+
+		for (int x = minX; x <= maxX; x++)
+		{
+			int chunkX = x >> 4;
+			for (int z = minZ; z <= maxZ; z++)
+			{
+				int chunkZ = z >> 4;
+				long chunkPos = ChunkPos.asLong(chunkX, chunkZ);
+				ChunkAccess chunk = this.chunkCache.computeIfAbsent(
+						chunkPos,
+						cp -> WorldHelper.getChunk(this.level, new ChunkPos(cp))
+				);
+				if (chunk == null) continue;
+
+				for (int y = minY; y <= maxY; y++)
+				{
+					blockpos.set(x, y, z);
+					long blockPosLong = blockpos.asLong();
+					BlockState state = this.stateCache.get(blockPosLong);
+					if (state == null)
+					{
+						LevelChunkSection section = WorldHelper.getChunkSection(chunk, y);
+						state = section.getBlockState(x & 15, y & 15, z & 15);
+						this.stateCache.put(blockPosLong, state);
+					}
+					if (state.isAir()) continue;
+
+					Collection<BlockTemp> blockTemps = BlockTempRegistry.getBlockTempsFor(state);
+					if (blockTemps.isEmpty() || (blockTemps.size() == 1 && blockTemps.contains(BlockTempRegistry.DEFAULT_BLOCK_TEMP)))
+					{   continue;
+					}
+					this.sources.add(new Source(blockpos.immutable(), state));
+				}
+			}
+		}
+	}
+
+	/** Phase B: for each source block, dispatch distance / occlusion / accumulation only to target positions within its affected radius. */
+	private void dispatchToPositions()
+	{
+		for (Source source : this.sources)
+		{
+			BlockPos src = source.pos();
+			BlockState state = source.state();
+
+			for (BlockPos pos : this.positions)
+			{
+				Collection<BlockTemp> blockTemps = BlockTempRegistry.getBlockTempsFor(state);
+
+				// Pre-filter: whether any BlockTemp can still affect this position (mirrors BlockTempModifier.areAnyBlockTempsInRange).
+				if (!this.areAnyBlockTempsInRange(pos, blockTemps)) continue;
+
+				// The observer is this target position: move the dummy there to preserve getTemperature(entity) semantics.
+				this.entity.setPos(CSMath.getCenterPos(pos));
+
+				// Source block center, closest point on the observer, and the distance between them.
+				Vec3 srcPos = CSMath.getCenterPos(src);
+				Vec3 playerClosest = WorldHelper.getClosestPointOnEntity(this.entity, srcPos);
+				Vec3 ray = srcPos.subtract(playerClosest);
+				Direction direction = Direction.getNearest(ray.x, ray.y, ray.z);
+				double distance = CSMath.getDistance(playerClosest, srcPos);
+				if (distance < 0 || distance > this.range) continue;
+
+				// Occlusion count: blocks blocking between the observer and the source block.
+				int[] blocksOccluding = new int[1];
+				WorldHelper.forBlocksInRay(playerClosest, srcPos, this.level, this.getChunk(src), this.stateCache,
+						(rayState, bpos) ->
+						{
+							if (!bpos.equals(src) && WorldHelper.isSpreadBlocked(this.level, rayState, bpos, direction, direction))
+							{   blocksOccluding[0]++;
+							}
+						}, 3);
+
+				for (BlockTemp blockTemp : blockTemps)
+				{
+					if (!blockTemp.isValid(this.level, src, state)) continue;
+					double temperature = blockTemp.getTemperature(this.level, this.entity, state, src, distance);
+					if (temperature == 0) continue;
+					this.accumulate(pos, blockTemp, temperature, blocksOccluding[0], distance);
+					break; // As in BlockTempModifier: each source block takes only the first effective BlockTemp.
+				}
+			}
+		}
+	}
+
+	/** Performs one accumulation for a (source block, target pos) pair; clamping semantics align with BlockTempModifier. */
+	private void accumulate(BlockPos pos, BlockTemp blockTemp, double temperature, int blocksOccluding, double distance)
+	{
+		Map<BlockTemp, Double> posTotals = this.totals.computeIfAbsent(pos, p -> Maps.newHashMap());
+		double blockTempTotal = posTotals.getOrDefault(blockTemp, 0d);
+		double blockGroupTotal = this.getGroupTotal(pos, blockTemp);
+		double blockGroupDelta = blockGroupTotal - blockTempTotal;
+
+		double tempToAdd = blockTemp.fade()
+				? CSMath.blend(temperature, 0, distance, 0.5, blockTemp.range())
+				: temperature;
+
+		double newVal;
+		if (blockTemp.logarithmic())
+		{
+			double newTotal = Math.pow(Math.pow(blockTempTotal, 1 / LOG_FACTOR) + tempToAdd, LOG_FACTOR);
+			double delta = newTotal - blockTempTotal;
+			delta /= (blocksOccluding + 1);
+			newVal = CSMath.clamp(blockTempTotal + delta,
+					blockTemp.minEffect() + blockGroupDelta,
+					blockTemp.maxEffect() - blockGroupDelta);
+		}
+		else
+		{
+			tempToAdd /= (blocksOccluding + 1);
+			newVal = CSMath.clamp(blockTempTotal + tempToAdd,
+					blockTemp.minEffect() + blockGroupDelta,
+					blockTemp.maxEffect() - blockGroupDelta);
+		}
+
+		posTotals.put(blockTemp, newVal);
+		this.updateGroupTotal(pos, blockTemp, newVal - blockTempTotal);
+	}
+
+	private double getGroupTotal(BlockPos pos, BlockTemp blockTemp)
+	{
+		if (!(blockTemp instanceof ConfiguredBlockTemp config) || config.getData().effectGroup().isEmpty())
+		{   return this.totals.getOrDefault(pos, Map.of()).getOrDefault(blockTemp, 0d);
+		}
+		return this.groupTotals.getOrDefault(pos, Map.of()).getOrDefault(config.getData().effectGroup().get(), 0D);
+	}
+
+	/** Pre-filter: whether any BlockTemp can still affect a position (mirrors BlockTempModifier.areAnyBlockTempsInRange). */
+	private boolean areAnyBlockTempsInRange(BlockPos pos, Collection<BlockTemp> blockTemps)
+	{
+		Map<BlockTemp, Double> posTotals = this.totals.getOrDefault(pos, Map.of());
+		for (BlockTemp blockTemp : blockTemps)
+		{
+			if (!posTotals.containsKey(blockTemp))
+			{   return true;
+			}
+			double effectTotal = this.getGroupTotal(pos, blockTemp);
+			if (CSMath.betweenInclusive(effectTotal, blockTemp.minEffect(), blockTemp.maxEffect()))
+			{   return true;
+			}
+		}
+		return false;
+	}
+
+	private void updateGroupTotal(BlockPos pos, BlockTemp blockTemp, double delta)
+	{
+		if (blockTemp instanceof ConfiguredBlockTemp config) {
+			config.getData().effectGroup().ifPresent(tempDataTagKey -> this.groupTotals.computeIfAbsent(
+					pos, p -> Maps.newHashMap()
+			).merge(tempDataTagKey, delta, Double::sum));
+		}
+	}
+
+	private ChunkAccess getChunk(BlockPos pos)
+	{   return WorldHelper.getChunk(this.level, pos);
+	}
+
+	/** Computes the AABB union covered by all positions, expanded outward by range. */
+	private long[] getRegionBounds()
+	{
+		int minX = Integer.MAX_VALUE;
+		int minY = Integer.MAX_VALUE;
+		int minZ = Integer.MAX_VALUE;
+		int maxX = Integer.MIN_VALUE;
+		int maxY = Integer.MIN_VALUE;
+		int maxZ = Integer.MIN_VALUE;
+		for (BlockPos pos : this.positions)
+		{
+			minX = Math.min(minX, pos.getX()); maxX = Math.max(maxX, pos.getX());
+			minY = Math.min(minY, pos.getY()); maxY = Math.max(maxY, pos.getY());
+			minZ = Math.min(minZ, pos.getZ()); maxZ = Math.max(maxZ, pos.getZ());
+		}
+		return new long[] { minX - this.range, minY - this.range, minZ - this.range,
+				maxX + this.range, maxY + this.range, maxZ + this.range };
+	}
+
+	// Candidate source blocks hit during phase A (state already read, so phase B does not read it again).
+	private record Source(BlockPos pos, BlockState state) {
+	}
+}

--- a/src/main/java/com/momosoftworks/coldsweat/util/world/WorldHelper.java
+++ b/src/main/java/com/momosoftworks/coldsweat/util/world/WorldHelper.java
@@ -1,5 +1,8 @@
 package com.momosoftworks.coldsweat.util.world;
 
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
 import com.mojang.datafixers.util.Pair;
 import com.momosoftworks.coldsweat.api.registry.BlockTempRegistry;
 import com.momosoftworks.coldsweat.api.temperature.block_temp.BlockTemp;
@@ -7,20 +10,23 @@ import com.momosoftworks.coldsweat.api.temperature.modifier.*;
 import com.momosoftworks.coldsweat.api.util.Temperature;
 import com.momosoftworks.coldsweat.common.blockentity.HearthBlockEntity;
 import com.momosoftworks.coldsweat.common.capability.handler.EntityTempManager;
+import com.momosoftworks.coldsweat.compat.CompatManager;
 import com.momosoftworks.coldsweat.config.ConfigSettings;
-import com.momosoftworks.coldsweat.data.codec.configuration.BiomeTempData;
-import com.momosoftworks.coldsweat.data.tag.ModBlockTags;
-import com.momosoftworks.coldsweat.util.entity.DummyEntity;
-import com.momosoftworks.coldsweat.util.entity.DummyPlayer;
 import com.momosoftworks.coldsweat.core.network.message.BlockDataUpdateMessage;
 import com.momosoftworks.coldsweat.core.network.message.ParticleBatchMessage;
 import com.momosoftworks.coldsweat.core.network.message.PlayEntityAttachedSoundMessage;
 import com.momosoftworks.coldsweat.core.network.message.SyncForgeDataMessage;
+import com.momosoftworks.coldsweat.data.codec.configuration.BiomeTempData;
+import com.momosoftworks.coldsweat.data.tag.ModBlockTags;
 import com.momosoftworks.coldsweat.util.ClientOnlyHelper;
-import com.momosoftworks.coldsweat.compat.CompatManager;
+import com.momosoftworks.coldsweat.util.entity.DummyEntity;
+import com.momosoftworks.coldsweat.util.entity.DummyPlayer;
 import com.momosoftworks.coldsweat.util.math.CSMath;
 import it.unimi.dsi.fastutil.longs.Long2ObjectOpenHashMap;
 import it.unimi.dsi.fastutil.longs.LongSet;
+import it.unimi.dsi.fastutil.objects.Object2DoubleMap;
+import it.unimi.dsi.fastutil.objects.Object2DoubleMaps;
+import it.unimi.dsi.fastutil.objects.Object2DoubleOpenHashMap;
 import net.minecraft.core.*;
 import net.minecraft.core.particles.ParticleOptions;
 import net.minecraft.core.registries.Registries;
@@ -46,7 +52,6 @@ import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.properties.BlockStateProperties;
 import net.minecraft.world.level.chunk.ChunkAccess;
 import net.minecraft.world.level.chunk.LevelChunkSection;
-
 import net.minecraft.world.level.levelgen.Heightmap;
 import net.minecraft.world.level.levelgen.structure.Structure;
 import net.minecraft.world.level.levelgen.structure.StructureStart;
@@ -68,7 +73,8 @@ import net.neoforged.neoforge.server.ServerLifecycleHooks;
 import javax.annotation.Nullable;
 import java.lang.reflect.Field;
 import java.util.*;
-import java.util.function.*;
+import java.util.function.BiConsumer;
+import java.util.function.Predicate;
 
 @EventBusSubscriber
 public abstract class WorldHelper
@@ -822,6 +828,166 @@ public abstract class WorldHelper
         {   modifiers.add(new WarmthTempModifier(maxCoolingHeating.getSecond()));
         }
         return Temperature.apply(0, dummy, Temperature.Trait.WORLD, modifiers, true);
+    }
+
+    /**
+     * Batch-computes world temperatures for a collection of BlockPos positions within the same Level
+     * (full precision, semantically aligned with {@link #getTemperatureAt}).
+     * <br/>
+     * Shares work across positions: reuses the dummy modifier chain, replaces a per-position volume scan with
+     * a single region-union scan, and de-duplicates hearth insulation lookups per chunk. This amortizes the block
+     * volume-scan cost in clustered scenes from "once per container" to "once per region + one dispatch per container",
+     * bringing the overall cost close to O(n).
+     * <br/>
+     * Note: compared with the single-pos {@code getTemperatureAt}, this method is threshold-equivalent in normal
+     * scenarios (same cold/hot direction and magnitude), but not bit-for-bit identical because block accumulation
+     * order is affected by the dispatch.
+     *
+     * @param level     the world the temperatures belong to (must be the same Level)
+     * @param positions a batch of block positions to probe (duplicates allowed; de-duplicated internally)
+     * @return the world temperature (MC units) for each de-duplicated position
+     * @throws IllegalStateException if invoked on the logical client (temperature computation exists only on the server)
+     */
+    public static Object2DoubleMap<BlockPos> getTemperaturesAt(Level level, Collection<BlockPos> positions)
+    {
+        if (level.isClientSide)
+        {   throw new IllegalStateException("Cannot query world temperatures for batch on the client side.");
+        }
+
+        // De-duplicate and complete the sublevel transform.
+        Set<BlockPos> normalized = Sets.newLinkedHashSet();
+        for (BlockPos pos : positions)
+        {   normalized.add(sublevelToWorld(level, pos));
+        }
+        if (normalized.isEmpty())
+        {   return Object2DoubleMaps.emptyMap();
+        }
+
+        DummyPlayer dummy = getDummyPlayer(level);
+
+        // Single region-union scan plus per-position dispatch, producing each pos's block-temperature function.
+        BlockTempScanBatch blockScan = new BlockTempScanBatch(level, dummy, normalized, ConfigSettings.BLOCK_RANGE.get());
+        blockScan.scan();
+
+        // De-duplicated-per-chunk hearth insulation query.
+        Map<BlockPos, Pair<Integer, Integer>> insulation = getInsulationAtBatch(level, normalized, 2);
+
+        Object2DoubleMap<BlockPos> result = new Object2DoubleOpenHashMap<>();
+        for (BlockPos pos : normalized)
+        {
+            dummy.setPos(CSMath.getCenterPos(pos));
+            List<TempModifier> modifiers = Lists.newArrayList(Temperature.getModifiers(dummy, Temperature.Trait.WORLD));
+            // Replace the original BlockTempModifier in the chain with the batch block-temperature function,
+            // preserving the chain order.
+            replaceBlockTempsWithBatch(modifiers, blockScan, pos);
+
+            Pair<Integer, Integer> maxCoolingHeating = insulation.get(pos);
+            if (maxCoolingHeating != null)
+            {
+                if (maxCoolingHeating.getFirst() > 0)
+                {   modifiers.add(new FrigidnessTempModifier(maxCoolingHeating.getFirst()));
+                }
+                if (maxCoolingHeating.getSecond() > 0)
+                {   modifiers.add(new WarmthTempModifier(maxCoolingHeating.getSecond()));
+                }
+            }
+            result.put(pos, Temperature.apply(0, dummy, Temperature.Trait.WORLD, modifiers, true));
+        }
+        return result;
+    }
+
+    /**
+     * Batch-computes "rough" world temperatures for a collection of BlockPos positions within the same Level,
+     * semantically aligned with {@link #getRoughTemperatureAt(Level, BlockPos, int)} and reusing the 8-block
+     * segment temperature cache (Rough cache).
+     *
+     * @param level     the world the temperatures belong to
+     * @param positions a batch of block positions to probe (duplicates allowed)
+     * @param flags     the same cache-flag bitmask as getRoughTemperatureAt (1=Sensitive, 2=Force Update)
+     * @return the rough world temperature (MC units) for each position
+     */
+    public static Object2DoubleMap<BlockPos> getRoughTemperaturesAt(Level level, Collection<BlockPos> positions, int flags)
+    {
+        Object2DoubleMap<BlockPos> result = new Object2DoubleOpenHashMap<>();
+        for (BlockPos pos : positions)
+        {   result.put(pos, getRoughTemperatureAt(level, pos, flags));
+        }
+        return result;
+    }
+
+    /**
+     * Replaces the original {@code BlockTempModifier} in a temperature-modifier chain with the block-temperature
+     * function produced by the batch computation (the replacement happens on a cloned list and does not touch the
+     * original modifiers mounted on the dummy).
+     */
+    private static void replaceBlockTempsWithBatch(List<TempModifier> modifiers, BlockTempScanBatch blockScan, BlockPos pos)
+    {
+        for (int i = 0; i < modifiers.size(); i++)
+        {
+            if (modifiers.get(i) instanceof BlockTempModifier)
+            {   modifiers.set(i, new BatchBlockTempModifier(blockScan.getFunction(pos)));
+            }
+        }
+    }
+
+    /**
+     * De-duplicated-per-chunk hearth insulation batch query: each chunk is read only once, and its Hearth block
+     * entities back-fill all target positions through their path lookup.
+     *
+     * @param level       the world the temperatures belong to
+     * @param positions   a batch of block positions to probe (duplicates allowed)
+     * @param chunkRadius radius (in chunks) to be searched for hearth block entities
+     *
+     * @return the (max cooling level, max heating level) for each target position
+     */
+    public static Map<BlockPos, Pair<Integer, Integer>> getInsulationAtBatch(Level level, Collection<BlockPos> positions, int chunkRadius)
+    {
+        Set<BlockPos> wholeBatch = Sets.newLinkedHashSet();
+        for (BlockPos pos : positions)
+        {   wholeBatch.add(sublevelToWorld(level, pos));
+        }
+
+        Map<BlockPos, Pair<Integer, Integer>> results = Maps.newHashMap();
+        // Collect the chunk union to scan.
+        Set<ChunkPos> chunkSet = Sets.newLinkedHashSet();
+        for (BlockPos pos : wholeBatch)
+        {
+            ChunkPos chunkPos = new ChunkPos(pos);
+            for (int x = -chunkRadius; x <= chunkRadius; x++)
+            for (int z = -chunkRadius; z <= chunkRadius; z++)
+            {   chunkSet.add(new ChunkPos(chunkPos.x + x, chunkPos.z + z));
+            }
+        }
+
+        for (ChunkPos chunkPos : chunkSet)
+        {
+            ChunkAccess chunk = getChunk(level, chunkPos.x, chunkPos.z);
+            if (chunk == null) continue;
+
+            for (BlockPos bePos : chunk.getBlockEntitiesPos())
+            {
+                BlockEntity be = chunk.getBlockEntity(bePos);
+                if (be instanceof HearthBlockEntity hearth)
+                {
+                    int cooling = hearth.getCoolingLevel();
+                    int heating = hearth.getHeatingLevel();
+                    for (BlockPos pos : wholeBatch)
+                    {
+                        if (hearth.getPathLookup().containsKey(pos))
+                        {
+                            results.compute(pos, (p, cur) -> cur == null
+                                                           ? Pair.of(cooling, heating)
+                                                           : Pair.of(Math.max(cur.getFirst(), cooling),
+                                                                     Math.max(cur.getSecond(), heating)));
+                        }
+                    }
+                }
+            }
+        }
+        for (BlockPos pos : wholeBatch)
+        {   results.putIfAbsent(pos, Pair.of(0, 0));
+        }
+        return results;
     }
 
     public static DummyPlayer getDummyPlayer(Level level)


### PR DESCRIPTION
## Summary

This PR adds two batch temperature-query methods to `WorldHelper`, letting addon mods compute world temperatures for many `BlockPos` positions in one pass instead of calling `getTemperatureAt`/`getRoughTemperatureAt` once per position:

```java
// Full precision, semantically aligned with getTemperatureAt
public static Object2DoubleMap<BlockPos> getTemperaturesAt(Level level, Collection<BlockPos> positions)

// Rough precision, reusing the existing 8-block segment cache
public static Object2DoubleMap<BlockPos> getRoughTemperaturesAt(Level level, Collection<BlockPos> positions, int flags)
```

## Motivation

Addons that periodically adjust gameplay state from world temperature — e.g. Freeze It, and Heat It!, which ticks the food inside every container in loaded chunks every N ticks — repeatedly query temperature at many positions on the same level within a single tick. Each individual `getTemperatureAt` call independently:

- rescans the full `(2 * blockRange)^3` block volume around the target position,
- rebuilds the dummy-player modifier chain,
- rescans the surrounding chunks for hearth insulation.

For clustered positions this repeats the same blockstate reads and chunk lookups over and over, making the tick cost roughly **O(N × V)** where V is the per-position scan volume. The batch API amortizes that shared work across the whole batch.
